### PR TITLE
k8s-secret-sync

### DIFF
--- a/cmd/k8s-secret-sync/main.go
+++ b/cmd/k8s-secret-sync/main.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/jackweinbender/k8s-secrets-sync/pkg/op"
-	"github.com/jackweinbender/k8s-secrets-sync/pkg/sync"
+	"github.com/jackweinbender/k8s-secret-sync/pkg/op"
+	"github.com/jackweinbender/k8s-secret-sync/pkg/sync"
 
 	// Import necessary packages for context, logging, Kubernetes client, and 1Password integration.
 	v1 "k8s.io/api/core/v1"
@@ -28,11 +28,11 @@ import (
 
 // Annotation keys and default values used for identifying and processing secrets.
 var (
-	annotationPrefix       = "k8s-secrets-sync.weinbender.io/" // Base prefix for all annotations used by this operator
-	annotationKeyProvider  = "provider"                        // Annotation to specify the secret provider (e.g., "op" for 1Password)
-	annotationKeyRef       = "ref"                             // Annotation to specify the reference or ID of the secret in the provider
-	annotationKeySecretKey = "secret-key"                      // Annotation to specify the key in the secret data to update
-	defaultSecretDataKey   = "value"                           // Default key in the secret data if annotation is not set
+	annotationPrefix       = "k8s-secret-sync.weinbender.io/" // Base prefix for all annotations used by this operator
+	annotationKeyProvider  = "provider"                       // Annotation to specify the secret provider (e.g., "op" for 1Password)
+	annotationKeyRef       = "ref"                            // Annotation to specify the reference or ID of the secret in the provider
+	annotationKeySecretKey = "secret-key"                     // Annotation to specify the key in the secret data to update
+	defaultSecretDataKey   = "value"                          // Default key in the secret data if annotation is not set
 )
 
 func annotationFor(key string) string {

--- a/example.yaml
+++ b/example.yaml
@@ -3,6 +3,6 @@ kind: Secret
 metadata:
   name: example-secret
   annotations:
-    k8s-secrets-sync.weinbender.io/ref: op://somevault/secret-item/credential # ref to the secret in the remote provider
-    k8s-secrets-sync.weinbender.io/provider: op # this is the `onepassword` provider
-    # k8s-secrets-sync.weinbender.io/secret-key # optional key to use in the secret, defaults to `value`
+    k8s-secret-sync.weinbender.io/ref: op://somevault/secret-item/credential # ref to the secret in the remote provider
+    k8s-secret-sync.weinbender.io/provider: op # this is the `onepassword` provider
+    # k8s-secret-sync.weinbender.io/secret-key # optional key to use in the secret, defaults to `value`

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jackweinbender/k8s-secrets-sync
+module github.com/jackweinbender/k8s-secret-sync
 
 go 1.23.1
 

--- a/pkg/op/provider.go
+++ b/pkg/op/provider.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/1password/onepassword-sdk-go"
-	"github.com/jackweinbender/k8s-secrets-sync/pkg/sync"
+	"github.com/jackweinbender/k8s-secret-sync/pkg/sync"
 )
 
 type secretProvider struct {


### PR DESCRIPTION
This pull request updates the project to use the corrected name `k8s-secret-sync` (removing the extra "s" from "secrets") across the codebase and documentation. The changes ensure consistency in module naming, import paths, and annotation prefixes, which is important for proper dependency resolution and integration with Kubernetes secrets.

**Project renaming and consistency updates:**

* Renamed the Go module in `go.mod` from `github.com/jackweinbender/k8s-secrets-sync` to `github.com/jackweinbender/k8s-secret-sync` to reflect the correct project name.
* Updated import paths in `cmd/k8s-secret-sync/main.go` and `pkg/op/provider.go` to use `k8s-secret-sync` instead of `k8s-secrets-sync`, ensuring all internal references match the new module name. [[1]](diffhunk://#diff-41c3760bd957bb033f5ab1b88ee83b464504cec62ee9758832ce0d0e50efd3f5L14-R15) [[2]](diffhunk://#diff-73b96a26f22b761fc6460bb5da97b7375c461c79d0758eaf33cd9658c7f39dafL9-R9)

**Annotation prefix standardization:**

* Changed the annotation prefix from `k8s-secrets-sync.weinbender.io/` to `k8s-secret-sync.weinbender.io/` in both code (`cmd/k8s-secret-sync/main.go`) and example YAML (`example.yaml`) to align with the new project name and prevent confusion in Kubernetes resource annotations. [[1]](diffhunk://#diff-41c3760bd957bb033f5ab1b88ee83b464504cec62ee9758832ce0d0e50efd3f5L31-R31) [[2]](diffhunk://#diff-20ced293329be4beaa1b0a78e4b4aa0bf8d60f7b12a8b7186ba8aa0c4082d804L6-R8)